### PR TITLE
Palette section fragment static method

### DIFF
--- a/src/commandpalette/index.ts
+++ b/src/commandpalette/index.ts
@@ -38,23 +38,6 @@ interface ICommandPaletteSection {
 
 
 /**
- * The current state of a command palette items.
- */
-export
-interface ICommandPaletteItemState {
-  /**
-   * The registration ID for a command palette item.
-   */
-  registrationID: string;
-
-  /**
-   * The run-time disabled status of a command palette item.
-   */
-  disabled: boolean;
-}
-
-
-/**
  * An object which can be added to a command palette section.
  */
 export

--- a/src/commandpalette/index.ts
+++ b/src/commandpalette/index.ts
@@ -38,6 +38,23 @@ interface ICommandPaletteSection {
 
 
 /**
+ * A group of items that can added to a command palette with headings.
+ */
+export
+interface ICommandPaletteSectionState {
+  /**
+   * A list of run-time registration IDs for a command palette section's items.
+   */
+  registrationIDs: string[];
+
+  /**
+   * A list of run-time disabled status for a command palette section's items.
+   */
+  disableds: boolean[];
+}
+
+
+/**
  * An object which can be added to a command palette section.
  */
 export

--- a/src/commandpalette/index.ts
+++ b/src/commandpalette/index.ts
@@ -38,19 +38,19 @@ interface ICommandPaletteSection {
 
 
 /**
- * A group of items that can added to a command palette with headings.
+ * The current state of a command palette items.
  */
 export
-interface ICommandPaletteSectionState {
+interface ICommandPaletteItemState {
   /**
-   * A list of run-time registration IDs for a command palette section's items.
+   * The registration ID for a command palette item.
    */
-  registrationIDs: string[];
+  registrationID: string;
 
   /**
-   * A list of run-time disabled status for a command palette section's items.
+   * The run-time disabled status of a command palette item.
    */
-  disableds: boolean[];
+  disabled: boolean;
 }
 
 

--- a/src/commandpalette/palette.ts
+++ b/src/commandpalette/palette.ts
@@ -697,7 +697,6 @@ class CommandPalette extends Widget implements ICommandPalette {
   private _renderSection(privSection: ICommandPaletteSectionPrivate): void {
     if (!privSection.items.some(id => this._registry[id].visible)) return;
     let constructor = this.constructor as typeof CommandPalette;
-    let content = this.contentNode;
     let section: ICommandPaletteSection = { text: privSection.text, items: [] };
     let registrationsIDs: string[] = [];
     let disableds: boolean[] = [];
@@ -710,11 +709,12 @@ class CommandPalette extends Widget implements ICommandPalette {
     });
     let fragment = constructor.createSectionFragment(section);
     let nodes = fragment.querySelectorAll(`.${COMMAND_CLASS}`);
+    // Update new command nodes with registrationID and disabled state.
     for (let i = 0; i < nodes.length; ++i) {
       nodes[i].setAttribute(REGISTRATION_ID, registrationsIDs[i]);
       if (disableds[i]) nodes[i].classList.add(DISABLED_CLASS);
     }
-    content.appendChild(fragment);
+    this.contentNode.appendChild(fragment);
   }
 
   /**

--- a/src/commandpalette/palette.ts
+++ b/src/commandpalette/palette.ts
@@ -34,7 +34,8 @@ import {
 } from '../commandregistry/index';
 
 import {
-  ICommandPalette, ICommandPaletteItem, ICommandPaletteSection
+  ICommandPalette, ICommandPaletteItem,
+  ICommandPaletteSection, ICommandPaletteSectionState
 } from './index';
 
 import {
@@ -189,6 +190,9 @@ class CommandPalette extends Widget implements ICommandPalette {
    *
    * @param item - The content for the palette item.
    *
+   * @param registrationID - An item ID that *must* be set as the value for the
+   * data attribute: `data-registration-id`
+   *
    * @param disabled - A flag denoting whether a palette item is disabled.
    *
    * @returns A new DOM node to use as an item in a command palette.
@@ -196,26 +200,46 @@ class CommandPalette extends Widget implements ICommandPalette {
    * #### Notes
    * This method may be reimplemented to create custom items.
    */
-  static createItemNode(item: ICommandPaletteItem, disabled: boolean): HTMLElement {
+  static createItemNode(item: ICommandPaletteItem, registrationID: string, disabled: boolean): HTMLElement {
     let node = document.createElement('li');
     let description = document.createElement('div');
     let shortcut = document.createElement('div');
-    node.classList.add(COMMAND_CLASS);
-    if (disabled) {
-      node.classList.add(DISABLED_CLASS);
-    }
-    description.classList.add(DESCRIPTION_CLASS);
-    shortcut.classList.add(SHORTCUT_CLASS);
+    node.className = COMMAND_CLASS;
+    description.className = DESCRIPTION_CLASS;
+    shortcut.className = SHORTCUT_CLASS;
+    if (disabled) node.classList.add(DISABLED_CLASS);
     node.textContent = item.title;
-    if (item.caption) {
-      description.textContent = item.caption;
-    }
-    if (item.shortcut) {
-      shortcut.textContent = item.shortcut;
-    }
+    if (item.caption) description.textContent = item.caption;
+    if (item.shortcut) shortcut.textContent = item.shortcut;
     node.appendChild(shortcut);
     node.appendChild(description);
+    node.setAttribute(REGISTRATION_ID, registrationID);
     return node;
+  }
+
+  /**
+   * Create a new section document fragment for a command palette.
+   *
+   * @param section - The section content.
+   *
+   * @param state - The registration IDs and disabled flags for a section.
+   *
+   * @returns A `DocumentFragment` with the whole rendered section.
+   *
+   * #### Notes
+   * This method may be reimplemented to create custom sections. Instead of
+   * returning a DOM node, it returns a `DocumentFragment` in order to allow
+   * for both single nodes and lists of nodes being generated.
+   */
+  static createSectionFragment(section: ICommandPaletteSection, state: ICommandPaletteSectionState): DocumentFragment {
+    let fragment = document.createDocumentFragment();
+    fragment.appendChild(this.createHeaderNode(section.text));
+    section.items.forEach((item, index) => {
+      let disabled = state.disableds[index]
+      let registrationID = state.registrationIDs[index];
+      fragment.appendChild(this.createItemNode(item, registrationID, disabled));
+    });
+    return fragment;
   }
 
   /**
@@ -338,7 +362,15 @@ class CommandPalette extends Widget implements ICommandPalette {
    * @param query - The query string
    */
   search(query: string): void {
-    matcher.search(query, this._searchItems()).then(results => {
+    let searchableItems = this._sections.reduce((acc, val) => {
+      val.items.forEach(id => {
+        let title = this._registry[id].item.title;
+        let caption = this._registry[id].item.caption;
+        acc.push({ id, title, caption });
+      });
+      return acc;
+    }, [] as ICommandSearchItem[]);
+    matcher.search(query, searchableItems).then(results => {
       this._bufferSearchResults(results);
     });
   }
@@ -676,36 +708,24 @@ class CommandPalette extends Widget implements ICommandPalette {
   /**
    * Render a section and its commands.
    */
-  private _renderSection(section: ICommandPaletteSectionPrivate): void {
-    if (!section.items.some(id => this._registry[id].visible)) return;
+  private _renderSection(privSection: ICommandPaletteSectionPrivate): void {
+    if (!privSection.items.some(id => this._registry[id].visible)) return;
     let constructor = this.constructor as typeof CommandPalette;
     let content = this.contentNode;
-    let header = constructor.createHeaderNode(section.text);
-    content.appendChild(header);
-    section.items.forEach(registrationID => {
+    let section: ICommandPaletteSection = { text: privSection.text, items: [] };
+    let sectionState: ICommandPaletteSectionState = {
+      disableds: [],
+      registrationIDs: []
+    };
+    privSection.items.forEach(registrationID => {
       let priv = this._registry[registrationID];
       if (!priv.visible) return;
-      let node = constructor.createItemNode(priv.item, priv.disabled);
-      node.setAttribute(REGISTRATION_ID, registrationID);
-      content.appendChild(node);
+      section.items.push(priv.item);
+      sectionState.disableds.push(priv.disabled);
+      sectionState.registrationIDs.push(registrationID);
     });
-  }
-
-  /**
-   * Return a list of searchable items for the matcher.
-   */
-  private _searchItems(): ICommandSearchItem[] {
-    return this._sections.reduce((acc, val) => {
-      val.items.forEach(id => {
-        let priv = this._registry[id];
-        acc.push({
-          id: id,
-          title: priv.item.title,
-          caption: priv.item.caption
-        });
-      });
-      return acc;
-    }, [] as ICommandSearchItem[]);
+    let fragment = constructor.createSectionFragment(section, sectionState);
+    content.appendChild(fragment);
   }
 
   /**


### PR DESCRIPTION
Up until now, only section headings and command nodes were renderable using static methods that could be overridden in a subclass. The main reason for this was that the "sections" are actually flat, one section is not one node, it's a list of nodes added to `contentNode`. I didn't want to impose that structure, nor did I want a `createSection` method that returned a single `HTMLElement`, because that also is a structure imposition.

So there are two concepts in this PR:

1. The new `createSection` static method returns a `DocumentFragment`, which means it *could* be a single `HTMLElement` or it could be a list of them, allowing for arbitrary layouts devised by subclasses.

2. The "state" information for each command: *i.e.*, its registration ID or its disabled status is no longer passed into the create methods. That is automatically set by the private `_renderSection` method. Subclasses should not have to worry about the implementation details that the `CommandPalette` requires for its mechanics to function.
