### PR TITLE
bugfix in disabled status, also listen to registry change events

### DIFF
--- a/example/yellow/index.ts
+++ b/example/yellow/index.ts
@@ -59,7 +59,8 @@ class YellowHandler {
     this._registry.add('demo:colors:yellow-1', createCommand());
     this._registry.add('demo:colors:yellow-2', createCommand());
     this._registry.add('demo:colors:yellow-3', createCommand());
-    this._registry.add('demo:colors:yellow-4', createCommand());
+    let record = this._registry.add('demo:colors:yellow-4', createCommand());
+    record.disabled = true;
     this._registry.add('demo:colors:yellow-5', createCommand());
 
     this._palette.add([

--- a/src/commandpalette/palette.ts
+++ b/src/commandpalette/palette.ts
@@ -257,6 +257,7 @@ class CommandPalette extends Widget implements ICommandPalette {
     this._commandRegistry = commandRegistry;
     commandRegistry.commandAdded.connect(this._commandUpdated, this);
     commandRegistry.commandRemoved.connect(this._commandUpdated, this);
+    commandRegistry.commandChanged.connect(this._commandUpdated, this);
   }
 
   /**
@@ -266,6 +267,7 @@ class CommandPalette extends Widget implements ICommandPalette {
     let commandRegistry = this._commandRegistry;
     commandRegistry.commandAdded.disconnect(this._commandUpdated, this);
     commandRegistry.commandRemoved.disconnect(this._commandUpdated, this);
+    commandRegistry.commandChanged.disconnect(this._commandUpdated, this);
     this._sections.length = 0;
     this._buffer.length = 0;
     this._registry = null;
@@ -389,8 +391,8 @@ class CommandPalette extends Widget implements ICommandPalette {
     // Ask the command registry about each palette commmand.
     Object.keys(this._registry).forEach(registrationID => {
       let priv = this._registry[registrationID];
-      priv.disabled = !this._commandRegistry.has(priv.item.id) ||
-        this._commandRegistry.isDisabled(priv.item.id);
+      let exists = this._commandRegistry.has(priv.item.id);
+      priv.disabled = !exists || this._commandRegistry.isDisabled(priv.item.id);
     });
     // Render the buffer.
     this._buffer.forEach(section => this._renderSection(section));
@@ -498,9 +500,9 @@ class CommandPalette extends Widget implements ICommandPalette {
   /**
    * A handler for command registry additions and removals.
    */
-  private _commandUpdated(sender: ICommandRegistry, args: string): void {
+  private _commandUpdated(sender: ICommandRegistry, id: string): void {
     let staleRegistry = Object.keys(this._registry).some(registrationID => {
-      return this._registry[registrationID].item.id === args;
+      return this._registry[registrationID].item.id === id;
     });
     if (staleRegistry) this.update();
   }

--- a/src/commandpalette/palette.ts
+++ b/src/commandpalette/palette.ts
@@ -389,7 +389,8 @@ class CommandPalette extends Widget implements ICommandPalette {
     // Ask the command registry about each palette commmand.
     Object.keys(this._registry).forEach(registrationID => {
       let priv = this._registry[registrationID];
-      priv.disabled = this._commandRegistry.isDisabled(priv.item.id);
+      priv.disabled = !this._commandRegistry.has(priv.item.id) ||
+        this._commandRegistry.isDisabled(priv.item.id);
     });
     // Render the buffer.
     this._buffer.forEach(section => this._renderSection(section));


### PR DESCRIPTION
Commands that are disabled now render correctly. Commands that are re-enabled after the palette has already been rendered now get updated by listening to the `commandChanged` signal.