### PR TITLE
format Accel as real key name

### DIFF
--- a/src/services/paletteregistry.ts
+++ b/src/services/paletteregistry.ts
@@ -249,10 +249,21 @@ namespace Private {
   }
 
   /**
+   * A flag indicating whether the platform is Mac.
+   */
+  let IS_MAC = !!navigator.platform.match(/Mac/i);
+
+  /**
+   * How to format Accel (Cmd on Mac, Ctrl elsewhere)
+   */
+  let ACCEL = IS_MAC ? 'Cmd' : 'Ctrl';
+
+  /**
    *
    */
   export
   function formatSequence(seq: string[]): string {
-    return seq.map(s => s.trim().replace(/\s+/g, '-')).join(' ');
+    
+    return seq.map(s => s.trim().replace(/\s+/g, '-').replace('Accel', ACCEL)).join(' ');
   }
 }

--- a/test/src/index.ts
+++ b/test/src/index.ts
@@ -234,12 +234,11 @@ describe('phosphide', () => {
           args: 0
         };
         short2 = {
-          sequence: ['Ctrl J'],
+          sequence: ['Accel J'],
           selector: '*',
           command: 'cmd:test',
           args: 1
         };
-
       });
 
       it('should return all valid sequences', () => {
@@ -252,7 +251,7 @@ describe('phosphide', () => {
         let results1 = shortcuts.getSequences('cmd:test', 1);
         expect(results1.length).to.be(1);
         expect(results1[0].length).to.be(1);
-        expect(results1[0][0]).to.be('Ctrl J');
+        expect(results1[0][0]).to.be('Accel J');
       });
 
       it('should perform deep equality test before adding', () => {


### PR DESCRIPTION
in command palette shortcut.

Avoid showing users the internal alias 'Accel'

Perhaps there should be a `normalized_seq` or `effective_seq` in keymap?