### PR TITLE
Let extensions return undefined as well as a promise.

### DIFF
--- a/src/core/extensionregistry.ts
+++ b/src/core/extensionregistry.ts
@@ -35,7 +35,9 @@ interface IExtension<T> {
    * specified by the `requires` property. This function will not be
    * called unless all requirements can be fulfilled.
    *
-   * The returned promise should resolve when activation is complete.
+   * If a promise is returned, the promise should resolve when the activation
+   * is complete. This allows a plugin to perform asynchronous actions (such
+   * as loading files) during its activation.
    */
   activate: (context: T, ...args: any[]) => Promise<void> | void;
 }

--- a/src/core/extensionregistry.ts
+++ b/src/core/extensionregistry.ts
@@ -37,7 +37,7 @@ interface IExtension<T> {
    *
    * The returned promise should resolve when activation is complete.
    */
-  activate: (context: T, ...args: any[]) => Promise<void>;
+  activate: (context: T, ...args: any[]) => Promise<void> | void;
 }
 
 


### PR DESCRIPTION
Many extensions do not need the resolver to wait, so there is no need to create a promise.