### PR TITLE
Capture keydown events

### DIFF
--- a/example/editor/index.ts
+++ b/example/editor/index.ts
@@ -37,16 +37,6 @@ function activateEditor(app: Application): Promise<void> {
     let editor = createEditor(i);
     app.shell.addToMainArea(editor);
   }
-  let command = 'editor:tab';
-  app.shortcuts.add([{
-    command,
-    selector: '.editor-CodeMirrorWidget',
-    sequence: ['Tab', 'Tab']
-  }]);
-  app.commands.add([{
-    id: command,
-    handler: () => { console.log('Double Tab key pressed;'); }
-  }]);
   return Promise.resolve<void>();
 }
 

--- a/example/editor/index.ts
+++ b/example/editor/index.ts
@@ -37,6 +37,16 @@ function activateEditor(app: Application): Promise<void> {
     let editor = createEditor(i);
     app.shell.addToMainArea(editor);
   }
+  let command = 'editor:tab';
+  app.shortcuts.add([{
+    command,
+    selector: '.editor-CodeMirrorWidget',
+    sequence: ['Tab', 'Tab']
+  }]);
+  app.commands.add([{
+    id: command,
+    handler: () => { console.log('Double Tab key pressed;'); }
+  }]);
   return Promise.resolve<void>();
 }
 

--- a/src/core/application.ts
+++ b/src/core/application.ts
@@ -459,7 +459,9 @@ class Application {
    * A subclass may reimplement this method as needed.
    */
   protected addEventsListeners(): void {
-    document.addEventListener('keydown', this);
+    // Keydown events are captured so that keyboard shortcuts can be
+    // invoked prior reaching editable elements.
+    document.addEventListener('keydown', this, true);
     window.addEventListener('resize', this);
   }
 

--- a/src/core/application.ts
+++ b/src/core/application.ts
@@ -459,7 +459,8 @@ class Application {
    * A subclass may reimplement this method as needed.
    */
   protected addEventsListeners(): void {
-    // Keydown events are captured so that keyboard shortcuts can be
+    // Keydown events are hooked during the capturing phase
+    // (vs the bubbling phase) so that keyboard shortcuts can be
     // invoked prior reaching editable elements.
     document.addEventListener('keydown', this, true);
     window.addEventListener('resize', this);


### PR DESCRIPTION
This allows us to capture events before they hit editable elements like CodeMirror.